### PR TITLE
Add builtin_interfaces dependency

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -10,6 +10,8 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>rosidl_default_generators</buildtool_depend>
 
+  <depend>builtin_interfaces</depend>
+
   <exec_depend>rosidl_default_runtime</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>


### PR DESCRIPTION
Buildfarm faild because of lack of the dependency to builtin_interfaces. This fix it. 